### PR TITLE
Overhauled Crosshair Cube

### DIFF
--- a/Assets/Scenes/TestingScenes/JamesTestFixables.unity
+++ b/Assets/Scenes/TestingScenes/JamesTestFixables.unity
@@ -644,6 +644,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+--- !u!1 &300725924 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+  m_PrefabInstance: {fileID: 637273724}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &418310622
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -862,6 +867,26 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6446061168560974835, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
   m_PrefabInstance: {fileID: 637273724}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &608863650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300725924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af3809f2a2035447bbf50bf4502a37bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MAXDISTANCE: 70
+  MAXCUBEDIST: 5000
+  cube: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
+  cubeAlpha: 0.5
+  alphaMat: {fileID: 2100000, guid: 53d95f797a6773942b0e7b3d6bb6ddf8, type: 2}
+  outOfRange: 0
+  hitSomething: 0
+  hitPoint: {x: 0, y: 0, z: 0}
 --- !u!1001 &637273724
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -966,7 +991,8 @@ PrefabInstance:
       propertyPath: pickUpText
       value: 
       objectReference: {fileID: 1898271616}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2614897911811143987, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
@@ -979,6 +1005,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2116380051}
+    - targetCorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 608863650}
   m_SourcePrefab: {fileID: 100100000, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
 --- !u!1 &705507993
 GameObject:

--- a/Assets/Scenes/TestingScenes/TestingFixableObjects.unity
+++ b/Assets/Scenes/TestingScenes/TestingFixableObjects.unity
@@ -1692,7 +1692,7 @@ PrefabInstance:
     - target: {fileID: 2614897911811143987, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: cube
       value: 
-      objectReference: {fileID: 847848485}
+      objectReference: {fileID: 0}
     - target: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: m_Name
       value: Player
@@ -1713,13 +1713,17 @@ PrefabInstance:
       propertyPath: pickUpText
       value: 
       objectReference: {fileID: 1898271616}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 2614897911811143987, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2102573530}
+    - targetCorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1536314245}
   m_SourcePrefab: {fileID: 100100000, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
 --- !u!114 &648275513 stripped
 MonoBehaviour:
@@ -2406,11 +2410,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &847848485 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-  m_PrefabInstance: {fileID: 1747178532}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &890573477
 GameObject:
   m_ObjectHideFlags: 0
@@ -4058,6 +4057,31 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 915628822}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+--- !u!1 &1536314240 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+  m_PrefabInstance: {fileID: 637273724}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1536314245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1536314240}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: af3809f2a2035447bbf50bf4502a37bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MAXDISTANCE: 70
+  MAXCUBEDIST: 5000
+  cube: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
+  cubeAlpha: 0.5
+  alphaMat: {fileID: 2100000, guid: 53d95f797a6773942b0e7b3d6bb6ddf8, type: 2}
+  outOfRange: 0
+  hitSomething: 0
+  hitPoint: {x: 0, y: 0, z: 0}
 --- !u!1 &1593427665
 GameObject:
   m_ObjectHideFlags: 0
@@ -4367,63 +4391,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1747178532
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_Name
-      value: CrosshairCube
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 72.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -33.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 5.293
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4836955553467272434, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
 --- !u!1 &1758639351
 GameObject:
   m_ObjectHideFlags: 0
@@ -5171,4 +5138,3 @@ SceneRoots:
   - {fileID: 1417939295}
   - {fileID: 1393247378}
   - {fileID: 456086765}
-  - {fileID: 1747178532}

--- a/Assets/Scripts/CrosshairCubeRayCast.cs
+++ b/Assets/Scripts/CrosshairCubeRayCast.cs
@@ -5,16 +5,19 @@ using UnityEngine;
 public class CrosshairCubeRayCast : MonoBehaviour
 {
 
-    public float MAXDISTANCE;
-    public float MAXCUBEDIST;
+    public float MAXDISTANCE = 70;
+    public float MAXCUBEDIST = 5000;
     [SerializeField] private GameObject cube;
     private Renderer cubeRenderer;
     private Material defaultCubeMat;
-    public float cubeAlpha;
+    private GameObject player;
+    public static float cubeAlpha = 0.5f;
     public Material alphaMat;
 
-    //outOfRange actually means that you are currently grappled and can't shoot right now
+    //outOfRange: You cannot grapple to this
     public bool outOfRange = false;
+    //shooting: The grapple is already shooting
+    public bool shooting = false;
 
     public RaycastHit hit;
     public bool hitSomething;
@@ -27,6 +30,8 @@ public class CrosshairCubeRayCast : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        player = transform.parent.gameObject;
+        cube = Instantiate(cube, new Vector3(0,0,0), Quaternion.identity);
         cubeRenderer = cube.GetComponent<Renderer>();
         //goalRenderer = goal.GetComponent<Renderer>();
     }
@@ -34,7 +39,7 @@ public class CrosshairCubeRayCast : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (outOfRange)
+        if (outOfRange || shooting)
         {
             CrosshairAlpha(0.5f);
         }
@@ -71,6 +76,33 @@ public class CrosshairCubeRayCast : MonoBehaviour
     public bool ChangeCube()
     {
         bool hitSomething = false;
+        if (Physics.Raycast(transform.position, transform.forward, out hit))
+        {
+            hitSomething = true;
+            Vector3 newVector = hit.point - transform.position;
+            if (!hit.collider.CompareTag("CUBE") && hit.collider.GetComponent<GrappleHead>() == null)
+            {
+                cube.transform.position = hit.point;
+                cube.transform.localScale = newVector.magnitude * (Vector3.one) / 16;
+                if (hit.distance > MAXDISTANCE)
+                {
+                    outOfRange = true;
+                }
+                else
+                {
+                    outOfRange = false;
+                }
+                setColor();
+
+                cubeRenderer.enabled = true;
+            }
+        }
+        else
+        {
+            hitSomething = false;
+            cubeRenderer.enabled = false;
+        }
+        /*
         //used to be 100
         if (Physics.Raycast(transform.position, transform.forward, out hit, MAXDISTANCE)) //not check for layer anymore
         {
@@ -134,7 +166,7 @@ public class CrosshairCubeRayCast : MonoBehaviour
             }
         }
         //If the object is too far to grapple, turn the crosshair cube gray but keep tracking it
-        else if (Physics.Raycast(transform.position, transform.forward, out hit, MAXCUBEDIST))
+        else if (Physics.Raycast(transform.position, transform.forward, out hit))
         {
             hitSomething = true;
             //HOLDS THE DISTANCE
@@ -163,6 +195,51 @@ public class CrosshairCubeRayCast : MonoBehaviour
             hitSomething = false;
             cubeRenderer.enabled = false;
         }
+        */
         return hitSomething;
     }
+
+    //Sets the color of the crosshair cube based on the object tag and mass passed in
+    //returns nothing
+    private void setColor()
+    {
+        if (hit.collider.CompareTag("Stopper"))
+        {
+            cubeRenderer.material.SetColor("_Color", colors["RED"]);
+        }
+        else if (hit.collider.CompareTag("MoveableObject"))
+        {
+            if (hit.rigidbody.mass >= player.GetComponent<Rigidbody>().mass * 1.5)
+            {
+                cubeRenderer.material.SetColor("_Color", colors["ORANGE"]);
+            }
+            else if (hit.rigidbody.mass <= player.GetComponent<Rigidbody>().mass / 1.5)
+            {
+                cubeRenderer.material.SetColor("_Color", colors["GREEN"]);
+            }
+            else
+            {
+                cubeRenderer.material.SetColor("_Color", colors["YELLOW"]);
+            }
+        }
+        else if (hit.collider.CompareTag("Grabbable"))
+        {
+            cubeRenderer.material.SetColor("_Color", colors["BLUE"]);
+        }
+        else
+        {
+            cubeRenderer.material.SetColor("_Color", colors["CYAN"]);
+        }
+
+    }
+
+    Dictionary<string, Color> colors = new Dictionary<string, Color>()
+    {
+        {"RED", new Color(1.0f, 0.0f, 0.0f, cubeAlpha) },
+        {"BLUE", new Color(0.0f, 0.0f, 1.0f, cubeAlpha) },
+        {"GREEN", new Color(0.0f, 1.0f, 0.0f, cubeAlpha) },
+        {"ORANGE", new Color(1.0f, .5f, 0.0f, cubeAlpha) },
+        {"YELLOW", new Color(1.0f, 1.0f, 0.0f, cubeAlpha) },
+        {"CYAN", new Color(0.0f, 1.0f, 1.0f, cubeAlpha) }
+    };
 }

--- a/Assets/Scripts/CrosshairCubeRayCast.cs.meta
+++ b/Assets/Scripts/CrosshairCubeRayCast.cs.meta
@@ -3,7 +3,9 @@ guid: af3809f2a2035447bbf50bf4502a37bd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - cube: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
+  - alphaMat: {fileID: 2100000, guid: 53d95f797a6773942b0e7b3d6bb6ddf8, type: 2}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 

--- a/Assets/Scripts/Grapple Head.cs
+++ b/Assets/Scripts/Grapple Head.cs
@@ -54,7 +54,7 @@ public class GrappleHead : MonoBehaviour
     }
     public void StartMovement(Vector3 startPosition, Vector3 direction)
     {
-        crc.outOfRange = true;
+        crc.shooting = true;
         if (retracting)
         {
             return;
@@ -168,7 +168,7 @@ public class GrappleHead : MonoBehaviour
         gameObject.SetActive(false);
         retracting = false;
         PlaySFX(doneRetracting, false);
-        crc.outOfRange = false;
+        crc.shooting = false;
     }
 
     //Plays the sound, prints stack trace to console if it cannot find the file

--- a/Assets/Scripts/PlayerGrapple.cs
+++ b/Assets/Scripts/PlayerGrapple.cs
@@ -160,7 +160,7 @@ public class PlayerGrapple : MonoBehaviour
                 Debug.Log(hit.transform.gameObject);
                 HingeJoint joint = gameObject.AddComponent<HingeJoint>();
                 joint.connectedBody = hit.transform.gameObject.GetComponent<Rigidbody>();
-                crc.MAXDISTANCE = 100f;
+                crc.MAXDISTANCE = 100f; //WHY ARE THESE VALUES HARDCODED
             }
         }
     }


### PR DESCRIPTION
The Crosshair Cube is now color-coded: Color code includes: -Red: Stopper
-Orange: heavy
-Yellow: medium
-Green: light
-Blue: Grabbable
-Cyan: all others
Alpha changes when object is out of range or you aren't able to grapple

I also switched to a prefab for the crosshair cube itself so that you don't have to manually set the cube variable everywhere.