### PR TITLE
Added Lever-Controlled Doors, Hatches

### DIFF
--- a/Assets/Scenes/TestingScenes/TestSaveAndLoad.unity
+++ b/Assets/Scenes/TestingScenes/TestSaveAndLoad.unity
@@ -1076,9 +1076,6 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 418310631}
-    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 418310637}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &418310623 stripped
 GameObject:
@@ -1269,6 +1266,7 @@ MonoBehaviour:
   - {fileID: 1417939296}
   allFixed: 0
   fixedString: Is it working?
+  react: 0
   openPos: {x: 10, y: 0, z: 0}
 --- !u!65 &456086762
 BoxCollider:
@@ -1383,31 +1381,67 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!1 &521641182 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-  m_PrefabInstance: {fileID: 637273724}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &521641187
-MonoBehaviour:
+--- !u!1001 &534971929
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 521641182}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af3809f2a2035447bbf50bf4502a37bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  MAXDISTANCE: 70
-  MAXCUBEDIST: 5000
-  cube: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-  alphaMat: {fileID: 2100000, guid: 53d95f797a6773942b0e7b3d6bb6ddf8, type: 2}
-  outOfRange: 0
-  shooting: 0
-  hitSomething: 0
-  hitPoint: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -43.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -39.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3242549122361363530, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4972446811722784074, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: goal
+      value: 
+      objectReference: {fileID: 102118944}
+    - target: {fileID: 7049842342309091168, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64c273613d5bda646be4ed8906f483e8, type: 3}
 --- !u!1 &549503942
 GameObject:
   m_ObjectHideFlags: 0
@@ -1563,94 +1597,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e43fb191acbe6cb40a1d796da89e7b9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &637273724
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -55.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 302.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -9.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1553643018557935149, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: crc
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: cube
-      value: 
-      objectReference: {fileID: 935092263}
-    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: goal
-      value: 
-      objectReference: {fileID: 102118944}
-    - target: {fileID: 7848632524417778751, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: pickUpText
-      value: 
-      objectReference: {fileID: 1898271616}
-    - target: {fileID: 9211640960753821600, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      propertyPath: pickUpText
-      value: 
-      objectReference: {fileID: 1898271616}
-    m_RemovedComponents:
-    - {fileID: 2614897911811143987, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-    - {fileID: 4141544342542343073, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1224613239}
-    - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1224613250}
-    - targetCorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 521641187}
-  m_SourcePrefab: {fileID: 100100000, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
 --- !u!114 &648275513 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1443362845494476120, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
@@ -3335,40 +3281,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1224613228 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
-  m_PrefabInstance: {fileID: 637273724}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1224613239
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1224613228}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a112a37b8e9ba7641988d8b9e272a737, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  options: {fileID: 0}
-  pauseMenu: {fileID: 0}
-  canPause: 1
---- !u!114 &1224613250
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1224613228}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7339eb51fdf337c4aa001c20a3708ceb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  areaPosition: {x: 0, y: 0, z: 0}
-  areaRotation: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1231161156
 GameObject:
   m_ObjectHideFlags: 0
@@ -3606,6 +3518,7 @@ MonoBehaviour:
   - {fileID: 648275513}
   allFixed: 0
   fixedString: Entire engine fixed
+  react: 0
 --- !u!4 &1393247378
 Transform:
   m_ObjectHideFlags: 0
@@ -3656,6 +3569,7 @@ MonoBehaviour:
   - {fileID: 2006448101}
   allFixed: 0
   fixedString: Engine doors now opening
+  react: 0
 --- !u!4 &1417939295
 Transform:
   m_ObjectHideFlags: 0
@@ -3683,6 +3597,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 548c3d5692ff44e45b6556c6368626c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  reportees: []
   isFixed: 0
 --- !u!1001 &1494384352
 PrefabInstance:
@@ -4852,12 +4767,16 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7054827177133817321, guid: a340d245ce603664794cf66055ccdca7, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 734014803}
   m_SourcePrefab: {fileID: 100100000, guid: a340d245ce603664794cf66055ccdca7, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
+  - {fileID: 534971929}
   - {fileID: 705507995}
   - {fileID: 102118945}
   - {fileID: 991955024}
@@ -4871,7 +4790,6 @@ SceneRoots:
   - {fileID: 1053871363}
   - {fileID: 418310622}
   - {fileID: 9074081388130719481}
-  - {fileID: 637273724}
   - {fileID: 808275923}
   - {fileID: 6963895205726218967}
   - {fileID: 444063266}
@@ -4891,4 +4809,3 @@ SceneRoots:
   - {fileID: 8003721757672595985}
   - {fileID: 2701591645020608983}
   - {fileID: 3264921817204679905}
-  - {fileID: 834150258793559805}

--- a/Assets/Scenes/TestingScenes/TestingFixableObjects.unity
+++ b/Assets/Scenes/TestingScenes/TestingFixableObjects.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.029643869, g: 0.017717203, b: 0.019852372, a: 1}
+  m_IndirectSpecularColor: {r: 0.02958505, g: 0.017664552, b: 0.019794535, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -123,6 +123,87 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &100822344
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1080655302277388634, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2339534613296835767, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: fixedString
+      value: WORK GODDAMMIT
+      objectReference: {fileID: 0}
+    - target: {fileID: 2339534613296835767, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: minions.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2339534613296835767, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: minions.Array.data[0]
+      value: 
+      objectReference: {fileID: 1417939296}
+    - target: {fileID: 3676112649658784383, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      propertyPath: m_Name
+      value: Hatch
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3676112649658784383, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 839487272}
+    - targetCorrespondingSourceObject: {fileID: 4355399330027890936, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 127177603}
+    - targetCorrespondingSourceObject: {fileID: 3103045111252967168, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2008884530}
+    - targetCorrespondingSourceObject: {fileID: 3103045111252967168, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2008884531}
+  m_SourcePrefab: {fileID: 100100000, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
 --- !u!1 &102118944
 GameObject:
   m_ObjectHideFlags: 0
@@ -137,6 +218,7 @@ GameObject:
   - component: {fileID: 102118946}
   - component: {fileID: 102118949}
   - component: {fileID: 102118950}
+  - component: {fileID: 102118951}
   m_Layer: 0
   m_Name: Goal
   m_TagString: Goal
@@ -249,6 +331,35 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 102118944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &102118951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102118944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &127177597 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4355399330027890936, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+  m_PrefabInstance: {fileID: 100822344}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &127177603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 127177597}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
@@ -477,6 +588,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 768081183}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 768081189}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &221347962
 GameObject:
@@ -494,6 +608,7 @@ GameObject:
   - component: {fileID: 221347968}
   - component: {fileID: 221347969}
   - component: {fileID: 221347970}
+  - component: {fileID: 221347971}
   m_Layer: 0
   m_Name: Grabbable
   m_TagString: Grabbable
@@ -654,6 +769,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &221347971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 221347962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &244549975 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
@@ -672,6 +799,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &244549988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244549975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &244549994
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -769,6 +908,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 801279560}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 801279566}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1001 &294498620
 PrefabInstance:
@@ -836,6 +978,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
       insertIndex: -1
       addedObject: {fileID: 648275520}
+    - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 648275526}
   m_SourcePrefab: {fileID: 100100000, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
 --- !u!1 &294498621 stripped
 GameObject:
@@ -858,6 +1003,7 @@ GameObject:
   - component: {fileID: 404682263}
   - component: {fileID: 404682269}
   - component: {fileID: 404682270}
+  - component: {fileID: 404682271}
   m_Layer: 0
   m_Name: Grabbable (6)
   m_TagString: Grabbable
@@ -1018,6 +1164,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &404682271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404682262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &418310622
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1112,6 +1270,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 418310637}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 418310643}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &418310623 stripped
 GameObject:
@@ -1153,6 +1314,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &418310637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 418310623}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &418310643
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1230,6 +1403,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2006448108}
+    - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2006448114}
   m_SourcePrefab: {fileID: 100100000, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
 --- !u!1 &444063267 stripped
 GameObject:
@@ -1251,6 +1427,7 @@ GameObject:
   - component: {fileID: 456086761}
   - component: {fileID: 456086766}
   - component: {fileID: 456086767}
+  - component: {fileID: 456086768}
   m_Layer: 0
   m_Name: Door
   m_TagString: Untagged
@@ -1274,6 +1451,7 @@ MonoBehaviour:
   - {fileID: 1417939296}
   allFixed: 0
   fixedString: Is it working?
+  react: 0
   openPos: {x: 0, y: 0, z: 0}
 --- !u!65 &456086762
 BoxCollider:
@@ -1389,6 +1567,18 @@ Rigidbody:
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!114 &456086767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 456086760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &456086768
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1611,6 +1801,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1733756386201357856, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
       insertIndex: -1
       addedObject: {fileID: 575582995}
+    - targetCorrespondingSourceObject: {fileID: 1733756386201357856, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 575583002}
   m_SourcePrefab: {fileID: 100100000, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
 --- !u!1 &575582987 stripped
 GameObject:
@@ -1630,6 +1823,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &575582995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575582987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &575583002
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1698,6 +1903,10 @@ PrefabInstance:
       value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      propertyPath: crc
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7135133530751734024, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       propertyPath: cube
       value: 
       objectReference: {fileID: 0}
@@ -1721,6 +1930,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2102573530}
+    - targetCorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2102573541}
     - targetCorrespondingSourceObject: {fileID: 7769617461335444141, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1536314245}
@@ -1760,6 +1972,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &648275526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 294498621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1771,6 +1995,7 @@ GameObject:
   - component: {fileID: 705507995}
   - component: {fileID: 705507994}
   - component: {fileID: 705507996}
+  - component: {fileID: 705507997}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -1867,6 +2092,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &705507997
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &746844456 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
@@ -1910,6 +2147,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &746844476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 746844456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &759545385
 GameObject:
   m_ObjectHideFlags: 0
@@ -1926,6 +2175,7 @@ GameObject:
   - component: {fileID: 759545386}
   - component: {fileID: 759545392}
   - component: {fileID: 759545393}
+  - component: {fileID: 759545394}
   m_Layer: 0
   m_Name: Grabbable (1)
   m_TagString: Grabbable
@@ -2086,6 +2336,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &759545394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759545385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &768081170 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
@@ -2115,12 +2377,36 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &768081189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 768081170}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &775046682 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3444291475278691953, guid: 2eeb01ce80beca04b95aea77fe556ddb, type: 3}
   m_PrefabInstance: {fileID: 930855850}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &775046685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 775046682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &775046688
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2294,6 +2580,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &801279566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 801279547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &808275919
 GameObject:
   m_ObjectHideFlags: 0
@@ -2307,6 +2605,7 @@ GameObject:
   - component: {fileID: 808275921}
   - component: {fileID: 808275920}
   - component: {fileID: 808275924}
+  - component: {fileID: 808275925}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -2405,6 +2704,35 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 808275919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &808275925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808275919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &839487270 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3676112649658784383, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+  m_PrefabInstance: {fileID: 100822344}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &839487272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 839487270}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
@@ -2561,6 +2889,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &915628822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 915628809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &915628828
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2773,6 +3113,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 3444291475278691953, guid: 2eeb01ce80beca04b95aea77fe556ddb, type: 3}
       insertIndex: -1
       addedObject: {fileID: 775046685}
+    - targetCorrespondingSourceObject: {fileID: 3444291475278691953, guid: 2eeb01ce80beca04b95aea77fe556ddb, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 775046688}
   m_SourcePrefab: {fileID: 100100000, guid: 2eeb01ce80beca04b95aea77fe556ddb, type: 3}
 --- !u!1 &991955023
 GameObject:
@@ -2784,6 +3127,7 @@ GameObject:
   m_Component:
   - component: {fileID: 991955024}
   - component: {fileID: 991955025}
+  - component: {fileID: 991955026}
   m_Layer: 0
   m_Name: Terrain
   m_TagString: Untagged
@@ -2814,6 +3158,18 @@ Transform:
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &991955025
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 991955023}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &991955026
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3044,6 +3400,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 244549988}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 244549994}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &1055471221
 GameObject:
@@ -3061,6 +3420,7 @@ GameObject:
   - component: {fileID: 1055471222}
   - component: {fileID: 1055471228}
   - component: {fileID: 1055471229}
+  - component: {fileID: 1055471230}
   m_Layer: 0
   m_Name: Grabbable (2)
   m_TagString: Grabbable
@@ -3221,6 +3581,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1055471230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1055471221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1057751244 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
@@ -3239,6 +3611,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1057751256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057751244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1057751262
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3399,6 +3783,7 @@ GameObject:
   - component: {fileID: 1086649353}
   - component: {fileID: 1086649359}
   - component: {fileID: 1086649360}
+  - component: {fileID: 1086649361}
   m_Layer: 0
   m_Name: Grabbable (4)
   m_TagString: Grabbable
@@ -3559,6 +3944,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1086649361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086649352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1231161156
 GameObject:
   m_ObjectHideFlags: 0
@@ -3575,6 +3972,7 @@ GameObject:
   - component: {fileID: 1231161157}
   - component: {fileID: 1231161163}
   - component: {fileID: 1231161164}
+  - component: {fileID: 1231161165}
   m_Layer: 0
   m_Name: Grabbable (3)
   m_TagString: Grabbable
@@ -3735,6 +4133,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1231161165
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231161156}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1308903808
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3816,6 +4226,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 746844470}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 746844476}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!114 &1381240906 stripped
 MonoBehaviour:
@@ -3839,6 +4252,7 @@ GameObject:
   - component: {fileID: 1393247378}
   - component: {fileID: 1393247377}
   - component: {fileID: 1393247379}
+  - component: {fileID: 1393247380}
   m_Layer: 0
   m_Name: EngineTracker1
   m_TagString: Untagged
@@ -3863,6 +4277,7 @@ MonoBehaviour:
   - {fileID: 648275513}
   allFixed: 0
   fixedString: Entire engine fixed
+  react: 0
 --- !u!4 &1393247378
 Transform:
   m_ObjectHideFlags: 0
@@ -3890,6 +4305,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1393247380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393247376}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1417939293
 GameObject:
   m_ObjectHideFlags: 0
@@ -3901,7 +4328,8 @@ GameObject:
   - component: {fileID: 1417939295}
   - component: {fileID: 1417939294}
   - component: {fileID: 1417939296}
-  - component: {fileID: 1417939297}
+  - component: {fileID: 1417939298}
+  - component: {fileID: 1417939299}
   m_Layer: 0
   m_Name: EngineDoorsTracker1
   m_TagString: Untagged
@@ -3926,6 +4354,7 @@ MonoBehaviour:
   - {fileID: 2006448101}
   allFixed: 0
   fixedString: Engine doors now opening
+  react: 0
 --- !u!4 &1417939295
 Transform:
   m_ObjectHideFlags: 0
@@ -3953,8 +4382,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 548c3d5692ff44e45b6556c6368626c9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  reportees: []
   isFixed: 0
---- !u!114 &1417939297
+--- !u!114 &1417939298
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3966,6 +4396,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!54 &1417939299
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417939293}
+  serializedVersion: 4
+  m_Mass: 0.0000001
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1001 &1494384352
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4056,6 +4513,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 915628822}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 915628828}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1 &1536314240 stripped
 GameObject:
@@ -4077,9 +4537,9 @@ MonoBehaviour:
   MAXDISTANCE: 70
   MAXCUBEDIST: 5000
   cube: {fileID: 220076110261478376, guid: 569e100370e5f7745a1b2670650afc54, type: 3}
-  cubeAlpha: 0.5
   alphaMat: {fileID: 2100000, guid: 53d95f797a6773942b0e7b3d6bb6ddf8, type: 2}
   outOfRange: 0
+  shooting: 0
   hitSomething: 0
   hitPoint: {x: 0, y: 0, z: 0}
 --- !u!1 &1593427665
@@ -4231,6 +4691,7 @@ GameObject:
   - component: {fileID: 1692840057}
   - component: {fileID: 1692840063}
   - component: {fileID: 1692840064}
+  - component: {fileID: 1692840065}
   m_Layer: 0
   m_Name: Grabbable (5)
   m_TagString: Grabbable
@@ -4391,6 +4852,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1692840065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1692840056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1758639351
 GameObject:
   m_ObjectHideFlags: 0
@@ -4403,6 +4876,7 @@ GameObject:
   - component: {fileID: 1758639353}
   - component: {fileID: 1758639352}
   - component: {fileID: 1758639355}
+  - component: {fileID: 1758639356}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -4472,6 +4946,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1758639356
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1758639351}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1852987122
 GameObject:
   m_ObjectHideFlags: 0
@@ -4483,6 +4969,7 @@ GameObject:
   - component: {fileID: 1852987124}
   - component: {fileID: 1852987123}
   - component: {fileID: 1852987125}
+  - component: {fileID: 1852987126}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -4519,6 +5006,18 @@ Transform:
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1852987125
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1852987122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1852987126
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4699,12 +5198,65 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2006448114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444063267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2008884522 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3103045111252967168, guid: c047e2e6bdaaf48a8a282750f6906c3e, type: 3}
+  m_PrefabInstance: {fileID: 100822344}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2008884530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2008884522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2008884531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2008884522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2102573519 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6403545265453732062, guid: a061f3fce3c6bf840b07d6815200209f, type: 3}
   m_PrefabInstance: {fileID: 637273724}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &2102573530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2102573519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2102573541
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4794,6 +5346,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1057751256}
+    - targetCorrespondingSourceObject: {fileID: 2470958757349148026, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1057751262}
   m_SourcePrefab: {fileID: 100100000, guid: 87017a8d426e0e443b8732597cb2b69d, type: 3}
 --- !u!1001 &2627759027073015766
 PrefabInstance:
@@ -4861,6 +5416,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 1733756386201357856, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
       insertIndex: -1
       addedObject: {fileID: 2627759027073015775}
+    - targetCorrespondingSourceObject: {fileID: 1733756386201357856, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2627759027073015782}
   m_SourcePrefab: {fileID: 100100000, guid: 103aafe01fa00aa4c9bf94430323d720, type: 3}
 --- !u!1 &2627759027073015767 stripped
 GameObject:
@@ -4880,6 +5438,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &2627759027073015775
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2627759027073015767}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2627759027073015782
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4957,6 +5527,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
       insertIndex: -1
       addedObject: {fileID: 6963895205726218975}
+    - targetCorrespondingSourceObject: {fileID: 673773161692140297, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6963895205726218981}
   m_SourcePrefab: {fileID: 100100000, guid: 7bf778d1cd6f8b04b8aad61b92410cf8, type: 3}
 --- !u!1 &6963895205726218968 stripped
 GameObject:
@@ -4976,6 +5549,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &6963895205726218975
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6963895205726218968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6963895205726218981
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5073,6 +5658,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7054827177133817321, guid: a340d245ce603664794cf66055ccdca7, type: 3}
       insertIndex: -1
       addedObject: {fileID: 9074081388130719490}
+    - targetCorrespondingSourceObject: {fileID: 7054827177133817321, guid: a340d245ce603664794cf66055ccdca7, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 9074081388130719497}
   m_SourcePrefab: {fileID: 100100000, guid: a340d245ce603664794cf66055ccdca7, type: 3}
 --- !u!1 &9074081388130719482 stripped
 GameObject:
@@ -5092,6 +5680,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &9074081388130719490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9074081388130719482}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fac0b0ac377be0c479e59e1905d44782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &9074081388130719497
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5138,3 +5738,4 @@ SceneRoots:
   - {fileID: 1417939295}
   - {fileID: 1393247378}
   - {fileID: 456086765}
+  - {fileID: 100822344}

--- a/Assets/Scripts/DoorOpen.cs
+++ b/Assets/Scripts/DoorOpen.cs
@@ -10,30 +10,19 @@ public class DoorOpen : Reportee
     float speed = 0.5f;
     bool open = false;
 
-    void Start()
+    public override void Start()
     {
+        closedPos = new Vector3(transform.position.x,
+            transform.position.y,
+            transform.position.z);
         base.Start();
     }
 
     void Update()
     {
-        if (allFixed && !open && react)
+        if (allFixed)
         {
             transform.position = Vector3.Lerp(transform.position, openPos, speed * Time.deltaTime);
-            if (transform.position == openPos)
-            {
-                open = !open;
-                react = false;
-            }
-        }
-        else if (allFixed && open && react)
-        {
-            transform.position = Vector3.Lerp(transform.position, closedPos, speed * Time.deltaTime);
-            if (transform.position == closedPos)
-            {
-                open = !open;
-                react = false;
-            }
         }
     }
 }

--- a/Assets/Scripts/DoorStates.cs
+++ b/Assets/Scripts/DoorStates.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DoorStates : MonoBehaviour
+{
+    public DoorState currentState = DoorState.CLOSED;
+    public Vector3 openPos;
+    public Vector3 closedPos;
+    private float speed = 0.5f;
+    public enum DoorState
+    {
+        OPEN,
+        CLOSED
+    }
+
+    public void ChangeState(DoorState state)
+    {
+        currentState = state;
+    }
+
+    public void OpenRoutine()
+    {
+        if (transform.position != openPos)
+            transform.position = Vector3.Lerp(transform.position, openPos, speed * Time.deltaTime);
+    }
+
+    public void ClosedRoutine()
+    {
+        if (transform.position != closedPos)
+            transform.position = Vector3.Lerp(transform.position, closedPos, speed * Time.deltaTime);
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        if (currentState == DoorState.OPEN)
+        {
+            OpenRoutine();
+        }
+        if (currentState == DoorState.CLOSED)
+        {
+            ClosedRoutine();
+        }
+    }
+
+    void Start()
+    {
+        closedPos = transform.position;
+    }
+}

--- a/Assets/Scripts/DoorStates.cs.meta
+++ b/Assets/Scripts/DoorStates.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36cae3f4ed7a340d4bcb998f4759339d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/HatchController.cs
+++ b/Assets/Scripts/HatchController.cs
@@ -17,7 +17,7 @@ public class HatchController : Reportee
 
     private void Update()
     {
-        if (!open && allFixed && react)
+        if (allFixed)
         {
             var m = hj.motor;
             m.force = 10;
@@ -27,23 +27,6 @@ public class HatchController : Reportee
             hj.useMotor = true;
             if (hj.angle == hj.limits.min)
             {
-                open = !open;
-                react = false;
-                hj.useMotor = false;
-                rb.isKinematic = true;
-            }
-        }
-        else if (open && allFixed && react)
-        {
-            var m = hj.motor;
-            m.force = 10;
-            m.targetVelocity = 10;
-            hj.motor = m;
-            rb.isKinematic = false;
-            hj.useMotor = true;
-            if (hj.angle == hj.limits.max)
-            {
-                open = !open;
                 react = false;
                 hj.useMotor = false;
                 rb.isKinematic = true;

--- a/Assets/Scripts/HatchStates.cs
+++ b/Assets/Scripts/HatchStates.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HatchStates : MonoBehaviour
+{
+    public enum HatchState
+    {
+        OPEN,
+        CLOSED
+    }
+    public HatchState currentState = HatchState.CLOSED;
+    HingeJoint hj;
+    Rigidbody rb;
+    // Start is called before the first frame update
+    void Start()
+    {
+        rb = GetComponent<Rigidbody>();
+        hj = GetComponent<HingeJoint>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (currentState == HatchState.OPEN)
+        {
+            OpenRoutine();
+        }
+        if (currentState == HatchState.CLOSED)
+        {
+            ClosedRoutine();
+        }
+    }
+
+    public void ChangeState(HatchState state)
+    {
+        currentState = state;
+    }
+
+    void ClosedRoutine()
+    {
+        var m = hj.motor;
+        m.force = 10;
+        m.targetVelocity = 10;
+        hj.motor = m;
+        rb.isKinematic = false;
+        hj.useMotor = true;
+        if (hj.angle == hj.limits.max)
+        {
+            hj.useMotor = false;
+            rb.isKinematic = true;
+        }
+    }
+
+    void OpenRoutine()
+    {
+        var m = hj.motor;
+        m.force = 10;
+        m.targetVelocity = -10;
+        hj.motor = m;
+        rb.isKinematic = false;
+        hj.useMotor = true;
+        if (hj.angle == hj.limits.min)
+        {
+            hj.useMotor = false;
+            rb.isKinematic = true;
+        }
+    }
+}

--- a/Assets/Scripts/HatchStates.cs.meta
+++ b/Assets/Scripts/HatchStates.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b2dcc6a831f44fa7a1e2358babd9790
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Lever.cs
+++ b/Assets/Scripts/Lever.cs
@@ -11,7 +11,7 @@ public class Lever : MonoBehaviour
         Right,
     }
     public STATE state;
-    public void ChangeState(STATE newState) 
+    public virtual void ChangeState(STATE newState) 
     {
         state = newState;
     }

--- a/Assets/Scripts/LeverDoor.cs
+++ b/Assets/Scripts/LeverDoor.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LeverDoor : Lever
+{
+    public DoorStates door;
+    Reporter rep;
+    bool doFix;
+    // Start is called before the first frame update
+    void Start()
+    {
+        rep = GetComponent<Reporter>();
+    }
+
+    public override void ChangeState(STATE newState)
+    {
+        base.ChangeState(newState);
+        doFix = true;
+    }
+    public override void LeftRoutine()
+    {
+        if (door.currentState != DoorStates.DoorState.OPEN)
+        {
+            door.ChangeState(DoorStates.DoorState.OPEN);
+        }
+    }
+
+    public override void RightRoutine()
+    {
+        if (door.currentState != DoorStates.DoorState.CLOSED)
+        {
+            door.ChangeState(DoorStates.DoorState.CLOSED);
+        }
+    }
+}

--- a/Assets/Scripts/LeverDoor.cs.meta
+++ b/Assets/Scripts/LeverDoor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4402d723f3cb5481a8a7a97f2077d111
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LeverHatch.cs
+++ b/Assets/Scripts/LeverHatch.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LeverHatch : Lever
+{
+    public HatchStates door;
+    Reporter rep;
+    bool doFix;
+    // Start is called before the first frame update
+    void Start()
+    {
+        rep = GetComponent<Reporter>();
+    }
+
+    public override void ChangeState(STATE newState)
+    {
+        base.ChangeState(newState);
+        doFix = true;
+    }
+    public override void LeftRoutine()
+    {
+        if (door.currentState != HatchStates.HatchState.OPEN)
+        {
+            door.ChangeState(HatchStates.HatchState.OPEN);
+        }
+    }
+
+    public override void RightRoutine()
+    {
+        if (door.currentState != HatchStates.HatchState.CLOSED)
+        {
+            door.ChangeState(HatchStates.HatchState.CLOSED);
+        }
+    }
+}

--- a/Assets/Scripts/LeverHatch.cs.meta
+++ b/Assets/Scripts/LeverHatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a2ef6ed26ad6465cbf3da37e15a94ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Reportee.cs
+++ b/Assets/Scripts/Reportee.cs
@@ -13,7 +13,7 @@ public class Reportee : MonoBehaviour
     //For example, Door objects use this when opening
     public bool react;
     // Start is called before the first frame update
-    protected void Start()
+    public virtual void Start()
     {
         myReporter = GetComponent<Reporter>();
         Debug.Log(myReporter);


### PR DESCRIPTION
HatchController and DoorOpen are to be used for any doors or hatches that are activated by a Reporter.

To use a Lever-Controlled Door or hatch, replace these scripts in the Door or Hatch with HatchStates or DoorStates, and in the Lever, use LeverDoor or LeverHatch as the script instead of Lever. Then, assign the Hatch or Door you want to control to the LeverDoor/LeverHatch script.

It operates as a state machine.